### PR TITLE
Quotes, URL, Bugfixes, Docs Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,59 @@ server is deployed at:
 
 https://go-acd.appspot.com
 
-# Install
-
-This project is go-gettable:
-
-```
-go get gopkg.in/acd.v0/...
-```
-
 # Usage
 
-In order to use this library, you must authenticate through the [token server](https://go-acd.appspot.com).
+In order to use this library, you must authenticate through the token server. A  (e.g. https://go-acd.appspot.com).
 
-## CLI
+Get and build:
 
-Run `acd help` for usage.
+```
+$ go get gopkg.in/acd.v0/cmd/acd
+$ go build gopkg.in/acd.v0/cmd/acd
+```
+
+Run:
+
+```
+$ $GOPATH/bin/acd ls acd://
+```
+
+Example output:
+
+```
+Backups Archived Music Pictures My Send-to-Kindle Docs
+```
+
+You may run `acd help` for additional usage information.
+
+## Config
+
+You must create a config file like the following and either store it as ~/.config/acd.json or provide an alternate file-path with "--config-file":
+
+```js
+{
+    "tokenFile": "/home/<user>/.config/acd-token.json",
+    "cacheFile": "/home/<user>/.config/acd-cache.json",
+    "timeout": 0,
+    "Oauth2RefreshUrl": "https://go-acd.appspot.com/refresh"
+}
+```
+
+`tokenFile` represents the file containing the oauth settings which must be present on disk and has permissions 0600. The file is used by the token package to produce a valid access token by calling the oauthServer with the refresh token. You may use the public server, which that has been provided for your convenience, to generate this file: https://go-acd.appspot.com . You should deploy your own server if the security of your files is a concern.
+
+`cacheFile` represents the file used by the client to cache the NodeTree. This file is not assumed to be present and will be created on the first run. It is gob-encoded node.Node.
+
+`timeout` configures the HTTP Client with a timeout after which the client will cancel the request and return. It is in `time.Duration` units (nanoseconds). A timeout of 0 means no timeout. See http://godoc.org/net/http#Client for more information.
+
+`defaultOauth2RefreshUrl` is the URL for the token-server.
+
+`timeout` and `defaultOauth2RefreshUrl` are optional. The default values are those shown. 
+
+If need help troubleshooting (it refuses to load the config or nothing seems to be happening), you may enable debug logging by passing "--log-level 4":
+
+```
+[ERROR] 2017/02/12 00:57:36 file has wrong permissions: want 0600 got -rw-rw-r--
+```
 
 ## Library
 
@@ -32,10 +70,50 @@ on how to use the library.
 
 # Contributions
 
-This repository does not accept pull requests. All contributions must go
-through [Phabricator](http://phabricator.nasreddine.com). Please refer
-to [Arcanist Quick Start](https://secure.phabricator.com/book/phabricator/article/arcanist_quick_start/)
-to install arc and learn basic commands.
+Contributions are welcome as pull requests.
+
+# Commit Style Guideline
+
+We follow a rough convention for commit messages borrowed from Deis who
+borrowed theirs from CoreOS, who borrowed theirs from AngularJS. This is
+an example of a commit:
+
+    feat(token): remove dependency on file system.
+
+    use an IO.Reader and IO.Writer to deal with the token.
+
+To make it more formal, it looks something like this:
+    {type}({scope}): {subject}
+    <BLANK LINE>
+    {body}
+    <BLANK LINE>
+    {footer}
+
+The {scope} can be anything specifying place of the commit change.
+
+The {subject} needs to use imperative, present tense: “change”, not “changed” nor
+“changes”. The first letter should not be capitalized, and there is no dot (.) at the end.
+
+Just like the {subject}, the message {body} needs to be in the present tense, and includes
+the motivation for the change, as well as a contrast with the previous behavior. The first
+letter in a paragraph must be capitalized.
+
+All breaking changes need to be mentioned in the {footer} with the description of the
+change, the justification behind the change and any migration notes required.
+
+Any line of the commit message cannot be longer than 72 characters, with the subject line
+limited to 50 characters. This allows the message to be easier to read on github as well
+as in various git tools.
+
+The allowed {types} are as follows:
+
+    feat -> feature
+    fix -> bug fix
+    docs -> documentation
+    style -> formatting
+    ref -> refactoring code
+    test -> adding missing tests
+    chore -> maintenance
 
 # Credits
 
@@ -46,6 +124,6 @@ following:
 - [yadayada/acd_cli](https://github.com/yadayada/acd_cli)
 - [caseymrm/drivesink](https://github.com/caseymrm/drivesink)
 
-# License
+# License ![License](https://img.shields.io/badge/license-MIT-blue.svg?style=plastic)
 
-Refer to the LICENSE file.
+The MIT License (MIT) - see LICENSE for more details

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ $GOPATH/bin/acd ls acd://
 Example output:
 
 ```
-Backups Archived Music Pictures My Send-to-Kindle Docs
+"Archived Music" "Pictures" "My Send-to-Kindle Docs" "test-file-with-quote\""
 ```
 
 You may run `acd help` for additional usage information.

--- a/cli/ls.go
+++ b/cli/ls.go
@@ -91,7 +91,9 @@ func lsLong(nodes node.Nodes) {
 func lsShort(nodes node.Nodes) {
 	sep := ""
 	for _, n := range nodes {
-		fmt.Printf("%s%s", sep, n.Name)
+		name := strings.Replace(n.Name, "\\", "\\\\", -1)
+		name = strings.Replace(name, "\"", "\\\"", -1)
+		fmt.Printf("%s\"%s\"", sep, name)
 		sep = " "
 	}
 	fmt.Println("")

--- a/client.go
+++ b/client.go
@@ -97,7 +97,11 @@ func New(configFile string) (*Client, error) {
 
 // Close finalizes the acd.
 func (c *Client) Close() error {
-	return c.NodeTree.Close()
+	if c.NodeTree != nil {
+		return c.NodeTree.Close()
+	}
+
+	return nil
 }
 
 // Do invokes net/http.Client.Do(). Refer to net/http.Client.Do() for documentation.

--- a/node/node.go
+++ b/node/node.go
@@ -110,8 +110,13 @@ func (n *Node) RemoveChild(child *Node) {
 			if i < len(n.Nodes)-1 {
 				copy(n.Nodes[i:], n.Nodes[i+1:])
 			}
-			n.Nodes[len(n.Nodes)-1] = nil
-			n.Nodes = n.Nodes[:len(n.Nodes)-1]
+
+			len_ := len(n.Nodes)
+			if len_ > 0 {
+				n.Nodes[len_-1] = nil
+				n.Nodes = n.Nodes[:len_-1]
+			}
+
 			found = true
 			break
 		}


### PR DESCRIPTION
Added documentation about the configuration file format. This was needed in order to know how to even run `acd`. Expanded "get" instruction to also describe build and run. I also added an example execution of `acd ls`. Since this requires a special "acd://<...>" URI to be given, it wasn't intuitive how to do this without the help. 

Added the ability to provide the token-server URL via the config (and removed your to-do comment regarding the same).

Added quotes to short-listing (otherwise it's very confusing when filenames include spaces). This will slash any existing quotes in the names.

When I deleted something via the Amazon UI and attempted to list via `acd`, it started crashing. I had to add a check for whether `c.NodeTree` was non-nil before calling `Close()` on it from `Client`'s `Close()`. I was still getting an index/range error, so I also needed to update the prune routine to do the (`len` - 1) things only if there are other nodes.

closes #8 